### PR TITLE
remove small square marker at the beginning of item in treeview

### DIFF
--- a/src/TreeView/widget/ui/TreeView.css
+++ b/src/TreeView/widget/ui/TreeView.css
@@ -38,6 +38,10 @@
 .gg_assoc_wrapper > .gg_row {
 }
 
+.gg_assoc_wrapper li{
+	list-style-type: none;
+}
+
 .gg_nochildren {
 	
 }


### PR DESCRIPTION
Instead of seeing the litter square, circle in 
* Item 1
* Item 2
  * Item 2a
  * Item 2b

It would be:
item 1
item 2
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;item 2a
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;item 2b
