### PR TITLE
Remove unnecessary popup when catching generic error

### DIFF
--- a/src/TreeView/widget/Commons.js
+++ b/src/TreeView/widget/Commons.js
@@ -354,13 +354,11 @@ dojo.setObject("TreeView.widget.Commons", (function() {
 			if (console)
 				console.error(msg);
 			widget.domNode.innerHTML = msg;
-			mx.ui.error(msg)
 			throw msg;
 	}
 
 	function error(e) {
 			console.error(e);
-			mx.ui.error(e);
 			throw e;
 	}
 


### PR DESCRIPTION
mx.ui.error shouldn't be used in a generic, low-level functions.