### PR TITLE
Allow a limit on the number of search query terms for GridViews

### DIFF
--- a/src/TreeView/GridView.xml
+++ b/src/TreeView/GridView.xml
@@ -480,6 +480,16 @@ Pmmn04F2ux1MpVI79I4q6jJMfXsbe3iMjYKIcDicKxQKt4qiWFRJi6Joe9iUkWER6C8e48eQCJLC
 			<category>3) Search</category>
 			<description>Default message to be displayed in the search box</description>
 		</property>
+		<property key="searchmaxquerysizeenabled" type="boolean" required="true" defaultValue="false">
+			<caption>Cap query size?</caption>
+			<category>3) Search</category>
+			<description></description>
+		</property>
+		<property key="searchmaxquerysize" type="integer" defaultValue="10">
+			<caption>Max query size</caption>
+			<category>3) Search</category>
+			<description>Number of terms to take into account. Any search terms beyond this will be ignored.</description>
+		</property>
 		<property key="searchlabeldataset" type="string" defaultValue="" required="false">
 			<caption>Search label dataset</caption>
 			<category>3) Search</category>

--- a/src/TreeView/widget/Commons.js
+++ b/src/TreeView/widget/Commons.js
@@ -1470,7 +1470,7 @@ dojo.declare("TreeView.widget.SearchControl", null,  {
 
 	},
 
-	getSearchConstraints : function(searchAttrs) {
+	getSearchConstraints : function(searchAttrs, limit) {
 		//search for term xpath
 		var xpath = "";
 
@@ -1480,6 +1480,10 @@ dojo.declare("TreeView.widget.SearchControl", null,  {
 		if (this.searchfilter) {
 			var filtervalues = dojo.map(this.searchfilter.split(/\s+/), mxui.html.escapeQuotes);
 
+			if (typeof limit !== 'undefined' && filtervalues.length > limit) {
+				filtervalues.splice(limit, filtervalues.length - limit);
+			}
+			
 			//we want every search value to occur at least once! In one of the attributes
 			xpath += "[(" + dojo.map(filtervalues, function(fv) {
 					return dojo.map(searchAttrs, function(attr) {

--- a/src/TreeView/widget/GridView.js
+++ b/src/TreeView/widget/GridView.js
@@ -595,8 +595,12 @@ mxui.widget.declare("TreeView.widget.GridView", {
 				}), function(column) {
 					return column.columnattr;
 				});
-
-			xpath += this.searchControl.getSearchConstraints(this.searchAttrs);
+			
+			if (this.searchmaxquerysizeenabled) {
+				xpath += this.searchControl.getSearchConstraints(this.searchAttrs, this.searchmaxquerysize);
+			} else {
+				xpath += this.searchControl.getSearchConstraints(this.searchAttrs);
+			}
 		}
 
 		xpath += this.filterManager.getSearchConstraints();
@@ -1038,6 +1042,8 @@ mxui.widget.declare("TreeView.widget.GridView", {
 		searchplaceholder : '',
 		searchlabeldataset: '',
 		realtimesearch    : false,
+		searchmaxquerysizeenabled	: false,
+		searchmaxquerysize : 10,
 		emptymessage      : '',
 		selectionref      : '',
 		selectionrefset   : '',


### PR DESCRIPTION
Allow a limit on the number of search query terms for GridViews. Currently, searching for large bodies of text (as in, 10 pages), can crash an application.
Limit disabled by default, so it is backwards compatible.