### PR TITLE
attribute keys where undefined when empty

### DIFF
--- a/src/TreeView/widget/Commons.js
+++ b/src/TreeView/widget/Commons.js
@@ -416,7 +416,7 @@ define([
                 var obj = {};
                 var hasdata = false;
                 for (var key in rawdata) {
-                    var val = obj[key] = rawdata[key][i];
+                    var val = obj[key] = rawdata[key][i] || ""; // if undefined make an empty string.
                     if (/^true$/.test(obj[key])) {
                         obj[key] = true;
                     } else if (/^false$/.test(obj[key])) {


### PR DESCRIPTION
Option properties like column class style, prefixes, post fixes where undefined, 
Problem can be solved be placing a space, as value.
Or by adding the OR statement.
