### PR TITLE
Release all graph nodes during uninitialize

### DIFF
--- a/src/TreeView/widget/TreeView.js
+++ b/src/TreeView/widget/TreeView.js
@@ -205,6 +205,13 @@ require([
             dojo.forEach(this.actions, function (action) {
                 action.free();
             });
+
+            // Free all graph nodes and their subscription
+            for (var key in this.dict) {
+				if (this.dict.hasOwnProperty(key)) {           
+					this.dict[key].free();
+				}
+			}
         },
 
         /* MWE: not sure if these suspended are supposed here, or where deliberately deleted before merging with main branch..


### PR DESCRIPTION
In our customer project we had exceptions in IE 11 in this widget while opening the page with the widget multiple times. This was caused by the graph nodes not being released. As a result, the subscriptions to the mendix objects were not released. We added code to the uninitialize and tested this in our customer project. We were able to pinpoint this by setting the log in graphNode.free to info.